### PR TITLE
Import 'common-location' Entity & Add To Module

### DIFF
--- a/src/common-locations/common-locations.module.ts
+++ b/src/common-locations/common-locations.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonLocationsController } from './common-locations.controller';
 import { CommonLocationsService } from './common-locations.service';
+import { CommonLocation } from './entities/common-location.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([CommonLocation])],
   controllers: [CommonLocationsController],
-  providers: [CommonLocationsService]
+  providers: [CommonLocationsService],
 })
 export class CommonLocationsModule {}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before this PR the 'common-location' entity was not connected to the larger 'common-location' module, which would've made connecting to the 'common-location' repository impossible.

**After The PR (Pull Request):**
After this PR the 'common-location' entity was connected to the larger 'common-location' module, ensuring that connections to the 'common-location' repository could be established once all remaining connections were instantiated.

**Why Was This Changed?**
We are going to need to be able to connect to the 'common-location' repository so that we can access data that would be helpful to our End User in the larger application.

**What Was Changed?**
An import of both the 'TypeOrmModule' and 'CommonLocation' entity were added to the larger file so that a connection could be made to the repository via the "imports" key passed to the "@Module()" decorator.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
#49 

**Mentions:** _(Type `@` then the person's name)_
N/A