### PR TITLE
Import 'CommonLocation' Entity & Add To Module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,20 +2,25 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { UsersModule } from './users/users.module';
+
+// Modules
+import { CommonLocationsModule } from './common-locations/common-locations.module';
 import { CoordinatesModule } from './coordinates/coordinates.module';
 import { MaterialsModule } from './materials/materials.module';
+import { UsersModule } from './users/users.module';
+
+// Entities
+import { CommonLocation } from './common-locations/entities/common-location.entity';
 import { Coordinate } from './coordinates/entities/coordinate.entity';
 import { Material } from './materials/entities/material.entity';
 import { User } from './users/entities/user.entity';
-import { CommonLocationsModule } from './common-locations/common-locations.module';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'db.sqlite',
-      entities: [Coordinate, Material, User],
+      entities: [CommonLocation, Coordinate, Material, User],
       synchronize: true,
     }),
     UsersModule,


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before the PR the larger application was unaware that there was a 'common-location' table or 'CommonLocation' entity that it could reference.

**After The PR (Pull Request):**
After the PR the larger application is now aware that there is a 'common-location' table and a 'CommonLocation' entity that it can reference.

**Why Was This Changed?**
In order for us to be able to access information inside the 'common-location' repository the larger application needs to know it exists. By adding the 'CommonLocation' entity to 'app.module.ts' we ensure that the larger application is aware of the entities existence. 

**What Was Changed?**
- Imported 'CommonLocation' Entity into 'app.module.ts', adding the entity to the "imports" key of the `@Module()` decorator

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Close #50 

**Mentions:** _(Type `@` then the person's name)_
N/A