### PR TITLE
Feat: Add Basic Scaffold To Connect Application To 'common-location' Repository

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { MaterialsModule } from './materials/materials.module';
 import { Coordinate } from './coordinates/entities/coordinate.entity';
 import { Material } from './materials/entities/material.entity';
 import { User } from './users/entities/user.entity';
+import { CommonLocationsModule } from './common-locations/common-locations.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { User } from './users/entities/user.entity';
     UsersModule,
     CoordinatesModule,
     MaterialsModule,
+    CommonLocationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,20 +2,25 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { UsersModule } from './users/users.module';
+
+// Modules
+import { CommonLocationsModule } from './common-locations/common-locations.module';
 import { CoordinatesModule } from './coordinates/coordinates.module';
 import { MaterialsModule } from './materials/materials.module';
+import { UsersModule } from './users/users.module';
+
+// Entities
+import { CommonLocation } from './common-locations/entities/common-location.entity';
 import { Coordinate } from './coordinates/entities/coordinate.entity';
 import { Material } from './materials/entities/material.entity';
 import { User } from './users/entities/user.entity';
-import { CommonLocationsModule } from './common-locations/common-locations.module';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'db.sqlite',
-      entities: [Coordinate, Material, User],
+      entities: [CommonLocation, Coordinate, Material, User],
       synchronize: true,
     }),
     UsersModule,

--- a/src/common-locations/common-locations.controller.spec.ts
+++ b/src/common-locations/common-locations.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonLocationsController } from './common-locations.controller';
+
+describe('CommonLocationsController', () => {
+  let controller: CommonLocationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommonLocationsController],
+    }).compile();
+
+    controller = module.get<CommonLocationsController>(CommonLocationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/common-locations/common-locations.controller.ts
+++ b/src/common-locations/common-locations.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('common-locations')
+export class CommonLocationsController {}

--- a/src/common-locations/common-locations.module.ts
+++ b/src/common-locations/common-locations.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonLocationsController } from './common-locations.controller';
 import { CommonLocationsService } from './common-locations.service';
+import { CommonLocation } from './entities/common-location.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([CommonLocation])],
   controllers: [CommonLocationsController],
-  providers: [CommonLocationsService]
+  providers: [CommonLocationsService],
 })
 export class CommonLocationsModule {}

--- a/src/common-locations/common-locations.module.ts
+++ b/src/common-locations/common-locations.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommonLocationsController } from './common-locations.controller';
+import { CommonLocationsService } from './common-locations.service';
+
+@Module({
+  controllers: [CommonLocationsController],
+  providers: [CommonLocationsService]
+})
+export class CommonLocationsModule {}

--- a/src/common-locations/common-locations.service.spec.ts
+++ b/src/common-locations/common-locations.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonLocationsService } from './common-locations.service';
+
+describe('CommonLocationsService', () => {
+  let service: CommonLocationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommonLocationsService],
+    }).compile();
+
+    service = module.get<CommonLocationsService>(CommonLocationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommonLocationsService {}

--- a/src/common-locations/entities/common-location.entity.ts
+++ b/src/common-locations/entities/common-location.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class CommonLocation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  materials: number[];
+}

--- a/src/coordinates/entities/coordinate.entity.ts
+++ b/src/coordinates/entities/coordinate.entity.ts
@@ -19,4 +19,7 @@ export class Coordinate {
 
   @Column()
   landmark_id: number;
+
+  @Column()
+  landmark_count: number;
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before this PR we had not created nor had we established a connection to the 'common-location' repository that would contain helpful data for our End Users.

**After The PR (Pull Request):**
After this PR we had created a basic 'common-location' repository that was wired up to the 'app.module.ts' so that the larger application could connect to the table and CRUD, giving our End Users access to more information they might find helpful.

**Why Was This Changed?**
Creating this table will afford our End Users a greater breadth of information retrieved when they are searching the application for materials, weapons, armor, and the like.

**What Was Changed?**
Several PRs are merged as a part of this merge into 'main':
- #47 - Added a "count" field so that End Users can see how many of a particular type / id are found at a specific location
- #56 - Added 'common-locations' directory with appropriate 'module', 'service', and 'controller' TypeScript files, each containing boilerplate code and imports to start development
- #57 - An 'entities' directory and 'entity' TypeScript file were created for the 'common-location' repository to instantiate an initial table structure
- #58 - Imported the 'common-location' entity into 'common-location.module' TypeScript file
- #59 - Imported and added the 'common-location' entity to the 'app.module' TypeScript file

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Close #42 

**Mentions:** _(Type `@` then the person's name)_
N/A