### PR TITLE
Create 'dtos/', 'create-common-location' DTO File

### DIFF
--- a/src/common-locations/dtos/create-common-location.dto.ts
+++ b/src/common-locations/dtos/create-common-location.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateCommonLocationDto {
+  @IsString()
+  name: string;
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before the PR there was no DTO that could easily be used to control how a 'common-location' record was instantiated within the database / repository.

**After The PR (Pull Request):**
After the PR there is now a DTO that could easily be used to control how a 'common-location' record can be instantiated within the database / repository.

**What Was Changed?**
1. A `dtos/` directory was added to the `common-locations/` directory which will hold all related DTOs to the methods contained within the Common Location module
2. A `create-common-location.dto.ts` file was created for the singular purpose of creating a Common Location record within the Repository

**Why Was This Changed?**
The `create-common-location` DTO file will be used for the `create()` service and the `createCommonLocation()` controller to limit the fields that can be utilized to create a 'common-location' within the database.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #69

**Mentions:** _(Type `@` then the person's name)_
N / A