### PR TITLE
Add `find`, `findOne` Methods

### DIFF
--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -15,4 +15,16 @@ export class CommonLocationsService {
 
     return this.repo.save(commonLocation);
   }
+
+  find() {
+    return this.repo.find({
+      select: {
+        name: true,
+      },
+    });
+  }
+
+  findOne(id: number) {
+    return this.repo.findOneBy({ id });
+  }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before the PR there was no way for the application to perform a GET request on the 'Common Locations' repository / table within the database.

**After The PR (Pull Request):**
After the PR there are now two methods within the 'service' that will allow the application to interact with the 'Common Locations' repository / table within the database. The 'service' can make use of a `find()` method, which at present returns all records within the table. Alternatively, the 'service' can make use of a `findOne()` method, which at present returns only a single record from the table.

**What Was Changed?**
- Add `find` method returning all records in the 'Common Location' table
- Add `findOne` method returning a single record matching its unique id value stored in the table

**Why Was This Changed?**
Before this PR there was no way for the application to perform a GET request on the 'Common Locations' repository / table within the database. Now there are two potential ways that the application can perform a GET request - one to get by `id` and the other to retrieve all records in that table. 

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resoves #72

**Mentions:** _(Type `@` then the person's name)_
N / A
