### PR TITLE
Add 'update-common-location' DTO

### DIFF
--- a/src/common-locations/dtos/update-common-location.dto.ts
+++ b/src/common-locations/dtos/update-common-location.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateCommonLocationDto {
+  @IsString()
+  @IsOptional()
+  name: string;
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no DTO file governing how a pre-existing 'Common Locations' record could be updated dynamically.

**After The PR (Pull Request):**
After the PR we now have access to an 'update-common-location' DTO which can be used to control how a pre-existing 'Common Locations' record can be updated.

**What Was Changed?**
- 'update-common-location.dto.ts' was added and populated for use in the PATCH route of the application for the 'Common Locations' repo

**Why Was This Changed?**
In order to offer Users the flexibility to update different key / value pairs for a particular "Common Location" record row a dedicated 'update-common-location' DTO needed to be constructed. Adding this in will give User's the flexibility to update only the fields they would like to update.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #75 

**Mentions:** _(Type `@` then the person's name)_
N / A