### PR TITLE
Add 'delete' Method To 'service'

### DIFF
--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -39,4 +39,14 @@ export class CommonLocationsService {
 
     return this.repo.save(commonLocation);
   }
+
+  async delete(id: number) {
+    const commonLocation = await this.findOne(id);
+
+    if (!commonLocation) {
+      throw new NotFoundException();
+    }
+
+    return this.repo.remove(commonLocation);
+  }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no method in the 'service' that allowed access to the repo which would facilitate deleting a specific record row from the 'common-locations' table.

**After The PR (Pull Request):**
After the PR, a 'delete()' method now exists which will allow an Admin User to remove a record from the 'common-locations' table in the database via the 'controller'.

**What Was Changed?**
- A 'delete()' method was added to the 'common-locations.service.ts' which will allow us to delete a specific record from the 'common-locations' database

**Why Was This Changed?**
Prior to the creation of this method an Admin did not have the ability to delete a specific record from the 'common-locations' table within the database. Upon the addition of this PR, that method now exists so it can be accessed by the Admin who will be able to delete records by utilizing a specific HTTP request and route in the 'controller'.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #77 

**Mentions:** _(Type `@` then the person's name)_
N / A