### PR TITLE
78 delete setup controller

### DIFF
--- a/src/common-locations/common-locations.controller.ts
+++ b/src/common-locations/common-locations.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { CommonLocationsService } from './common-locations.service';
 import { CreateCommonLocationDto } from './dtos/create-common-location.dto';
 import { UpdateCommonLocationDto } from './dtos/update-common-location.dto';
@@ -30,5 +38,10 @@ export class CommonLocationsController {
     @Body() body: UpdateCommonLocationDto,
   ) {
     return this.commonLocationsService.update(parseInt(id), body);
+  }
+
+  @Delete('/:id')
+  removeCommonLocation(@Param() id: string) {
+    return this.commonLocationsService.remove(parseInt(id));
   }
 }

--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -40,7 +40,7 @@ export class CommonLocationsService {
     return this.repo.save(commonLocation);
   }
 
-  async delete(id: number) {
+  async remove(id: number) {
     const commonLocation = await this.findOne(id);
 
     if (!commonLocation) {


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before the PR there was a 'service' that would allow a deletion, but no actual 'controller' that could route a request to the method which would remove a record from the 'common-locations' table within the database.

**After The PR (Pull Request):**
After the PR there will be a route that's been instantiated that will allow an Admin User to delete a specific record row from the 'common-locations' table within the database.

**What Was Changed?**
- The 'service' method name for deleting a record was changed from 'delete' to 'remove'
- A 'removeCommonLocation' method was added to the 'controller' which will allow an Admin User to remove a specific record from the database's 'common-locations' table

**Why Was This Changed?**
An Admin User needs to be able to remove a specific record from the 'common-locations' table in the database on the off-chance that it contains the wrong information, "dirtying" the surrounding data.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #78 

**Mentions:** _(Type `@` then the person's name)_
N / A