### PR TITLE
Feat: Prevent Duplicates From Being Created By `POST` Request

### DIFF
--- a/src/common-locations/common-locations.controller.ts
+++ b/src/common-locations/common-locations.controller.ts
@@ -19,7 +19,7 @@ export class CommonLocationsController {
 
   @Post()
   createCommonLocation(@Body() body: CreateCommonLocationDto) {
-    this.commonLocationsService.create(body.name);
+    return this.commonLocationsService.create(body.name);
   }
 
   @Get()

--- a/src/common-locations/common-locations.service.ts
+++ b/src/common-locations/common-locations.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CommonLocation } from './entities/common-location.entity';
@@ -10,7 +14,19 @@ export class CommonLocationsService {
     private readonly repo: Repository<CommonLocation>,
   ) {}
 
-  create(name: string) {
+  async create(name: string) {
+    const potentialDuplicateLocation = await this.repo.find({
+      where: { name },
+    });
+
+    if (potentialDuplicateLocation.length !== 0) {
+      const { id, name } = potentialDuplicateLocation[0];
+
+      throw new ConflictException(
+        `A 'common_location' record with a 'name' of ${name} already exists as id #${id}`,
+      );
+    }
+
     const commonLocation = this.repo.create({ name });
 
     return this.repo.save(commonLocation);


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR the application would create a record within the 'common-location' table regardless of whether such a duplication would instantiate a duplicate record.

**After The PR (Pull Request):**
After this PR the application now performs a search of the 'common-location' table to confirm whether or not creating the requested record would instantiate a duplicate. If such a creation would introduce a duplicate into the table, [409 Conflict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) is thrown; if such a creation would introduce a unique record, the record is instantiated.

**What Was Changed?**
- Added a duplicate record check in the `create()` method of the 'common-locations' service
  - Import `ConflictException`
  - Change `create()` to async
  - Instantiate 'potentialDuplicateLocation' variable from table
  - Check if variable is empty; if full, throw `ConflictException`
- Adjusted the `createCommonLocation()` method in the 'controller' to return the created record upon execution

**Why Was This Changed?**
As an Admin User I want to help "error check" myself when I'm loading in the related data that will populate fields in other tables as part of junctions. To do so I thought it would be helpful to throw an exception when a POST request is sent whose creation would instantiate a duplicate record. Once this PR is merged, that functionality will have been adopted by the larger application.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resoves #95 

**Mentions:** _(Type `@` then the person's name)_
N / A