### PR TITLE
Feat: Unique Cooking Effects - Setup Connection To SQLite Database

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { UsersModule } from './users/users.module';
 import { CommonLocation } from './common-locations/entities/common-location.entity';
 import { Coordinate } from './coordinates/entities/coordinate.entity';
 import { Material } from './materials/entities/material.entity';
+import { UniqueCookingEffect } from './unique-cooking-effects/entities/unique-cooking-effect.entity';
 import { User } from './users/entities/user.entity';
 
 @Module({
@@ -21,7 +22,13 @@ import { User } from './users/entities/user.entity';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'db.sqlite',
-      entities: [CommonLocation, Coordinate, Material, User],
+      entities: [
+        CommonLocation,
+        Coordinate,
+        Material,
+        UniqueCookingEffect,
+        User,
+      ],
       synchronize: true,
     }),
     UsersModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AppService } from './app.service';
 import { CommonLocationsModule } from './common-locations/common-locations.module';
 import { CoordinatesModule } from './coordinates/coordinates.module';
 import { MaterialsModule } from './materials/materials.module';
+import { UniqueCookingEffectsModule } from './unique-cooking-effects/unique-cooking-effects.module';
 import { UsersModule } from './users/users.module';
 
 // Entities
@@ -27,6 +28,7 @@ import { User } from './users/entities/user.entity';
     CoordinatesModule,
     MaterialsModule,
     CommonLocationsModule,
+    UniqueCookingEffectsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/unique-cooking-effects/entities/unique-cooking-effect.entity.ts
+++ b/src/unique-cooking-effects/entities/unique-cooking-effect.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class UniqueCookingEffect {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  description: string;
+}

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.spec.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UniqueCookingEffectsController } from './unique-cooking-effects.controller';
+
+describe('UniqueCookingEffectsController', () => {
+  let controller: UniqueCookingEffectsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UniqueCookingEffectsController],
+    }).compile();
+
+    controller = module.get<UniqueCookingEffectsController>(UniqueCookingEffectsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('unique-cooking-effects')
+export class UniqueCookingEffectsController {}

--- a/src/unique-cooking-effects/unique-cooking-effects.module.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 import { UniqueCookingEffectsController } from './unique-cooking-effects.controller';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([UniqueCookingEffect])],
   controllers: [UniqueCookingEffectsController],
-  providers: [UniqueCookingEffectsService]
+  providers: [UniqueCookingEffectsService],
 })
 export class UniqueCookingEffectsModule {}

--- a/src/unique-cooking-effects/unique-cooking-effects.module.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UniqueCookingEffectsController } from './unique-cooking-effects.controller';
+import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
+
+@Module({
+  controllers: [UniqueCookingEffectsController],
+  providers: [UniqueCookingEffectsService]
+})
+export class UniqueCookingEffectsModule {}

--- a/src/unique-cooking-effects/unique-cooking-effects.service.spec.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
+
+describe('UniqueCookingEffectsService', () => {
+  let service: UniqueCookingEffectsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UniqueCookingEffectsService],
+    }).compile();
+
+    service = module.get<UniqueCookingEffectsService>(UniqueCookingEffectsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UniqueCookingEffectsService {}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR, the larger application did not have access to / a reference for data that would be contained within the 'unique-cooking-effects' module.

**After The PR (Pull Request):**
After this PR the larger application will now have access to data contained within the 'unique-cooking-effects' module, allowing them the ability to refer to this data, persist data, and mutate data within this module.

**What Was Changed?**
| Pull Request | Description |
| :---: | --- |
| #108 | - Create an 'unique-cooking-effects' server and test file</br>- Create an 'unique-cooking-effects' controller and test file</br>- Create an 'unique-cooking-effects' module</br>- Import the larger 'UniqueCookingEffectsModule' into the 'App' module |
| #110 | - Create an 'entities/' directory within the 'unique-cooking-effects/' directory</br>- Create an 'unique-cooking-effects' entity as a base model for the larger table |
| #111 | - Import the 'UniqueCookingEffect' entity into 'unique-cooking-effect.module.ts' |
| #112 | - Import the 'UniqueCookingEffect' entity into the 'App' module |

**Why Was This Changed?**
In order for other tables within the larger database to support potential 'unique-cooking-effect' fields within their respective schema the 'unique-cooking-effects' module needed to be created to afford other resources that access. By implementing this PR, we are creating that access point for the larger application to refer to, persist, and mutate data contained within the larger 'unique-cooking-effects' module.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #41 

**Mentions:** _(Type `@` then the person's name)_
N / A