### PR TITLE
Connect 'unique-cooking-effect.entity.ts' To 'unique-cooking-effects.module.ts'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.module.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 import { UniqueCookingEffectsController } from './unique-cooking-effects.controller';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([UniqueCookingEffect])],
   controllers: [UniqueCookingEffectsController],
-  providers: [UniqueCookingEffectsService]
+  providers: [UniqueCookingEffectsService],
 })
 export class UniqueCookingEffectsModule {}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Before this PR the 'unique-cooking-effect' module did not have access to the 'unique-cooking-effect' entity which meant that there would be no way for the application to access, persist, or mutate data in the table via the repo.

**After The PR (Pull Request):**
After this PR the 'unique-cooking-effect' module will now have access to the 'unique-cooking-effect' entity, which is a part of the connection process between the larger module and its repo.

**What Was Changed?**
- Import the 'UniqueCookingEffect' entity into 'unique-cooking-effect.module.ts'

**Why Was This Changed?**
In order to connect the repo to the larger module, the entity needs to be imported. This PR imports the entity into the 'unique-cooking-effect.module.ts' file ensuring a connection between the module and the repo.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #52 

**Mentions:** _(Type `@` then the person's name)_
N / A
