### PR TITLE
Import 'UniqueCookingEffect' Entity Into 'App' Module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { UsersModule } from './users/users.module';
 import { CommonLocation } from './common-locations/entities/common-location.entity';
 import { Coordinate } from './coordinates/entities/coordinate.entity';
 import { Material } from './materials/entities/material.entity';
+import { UniqueCookingEffect } from './unique-cooking-effects/entities/unique-cooking-effect.entity';
 import { User } from './users/entities/user.entity';
 
 @Module({
@@ -21,7 +22,13 @@ import { User } from './users/entities/user.entity';
     TypeOrmModule.forRoot({
       type: 'sqlite',
       database: 'db.sqlite',
-      entities: [CommonLocation, Coordinate, Material, User],
+      entities: [
+        CommonLocation,
+        Coordinate,
+        Material,
+        UniqueCookingEffect,
+        User,
+      ],
       synchronize: true,
     }),
     UsersModule,


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR the larger application did not have access to the generalized structure / schema of the 'unique-cooking-effects' table.

**After The PR (Pull Request):**
After this PR the larger application now has access to the generalized structure / schema of the 'unique-cooking-effects' table.

**What Was Changed?**
- Import the 'UniqueCookingEffect' entity into the 'App' module

**Why Was This Changed?**
In order for the larger application (i.e. potentially other routes) to be able to access the data held within the 'unique-cooking-effect' table in the database, they'll need access to the 'UniqueCookingEffect' entity to be able to pull that data. This PR grants the larger application access to that information.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #53 

**Mentions:** _(Type `@` then the person's name)_
N / A