### PR TITLE
Add Imports, Create 'create' Method

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -1,4 +1,30 @@
-import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 
 @Injectable()
-export class UniqueCookingEffectsService {}
+export class UniqueCookingEffectsService {
+  constructor(
+    @InjectRepository(UniqueCookingEffect)
+    private readonly repo: Repository<UniqueCookingEffect>,
+  ) {}
+
+  async create(name: string, description: string) {
+    const potentialDuplicateCookingEffect = await this.repo.find({
+      where: { name },
+    });
+
+    if (potentialDuplicateCookingEffect.length !== 0) {
+      const { id, name } = potentialDuplicateCookingEffect[0];
+
+      throw new ConflictException(
+        `a 'unique_cooking_effect' record with a 'name' of ${name} already exists as id #${id}`,
+      );
+    }
+
+    const uniqueCookingEffect = this.repo.create({ name, description });
+
+    return this.repo.save(uniqueCookingEffect);
+  }
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no way for an Admin User to create a new record row within the 'unique-cooking-effect' table.

**After The PR (Pull Request):**
After this PR there is now a 'create()' method within the 'service' which will allow an Admin User to create a new record row within the 'unique-cooking-effect' table, assuming that the provided data for the new record row does not match a pre-existing record.

**What Was Changed?**
- Create an asynchronous 'create()' method that confirms the record to be created is unique prior to creating the record row within the 'unique-cooking-effects' table

**Why Was This Changed?**
This was changed so that an Admin User could create a new record row within the 'unique-cooking-effect' table after confirming that no identical record row exists within the table prior to instantiation.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #99 

**Mentions:** _(Type `@` then the person's name)_
N / A