### PR TITLE
Feat: Unique Cooking Effects - Setup 'controller' & 'service'

### DIFF
--- a/src/unique-cooking-effects/dtos/create-unique-cooking-effect.dto.ts
+++ b/src/unique-cooking-effects/dtos/create-unique-cooking-effect.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class CreateUniqueCookingEffectDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  description: string;
+}

--- a/src/unique-cooking-effects/dtos/update-unique-cooking-effect.dto.ts
+++ b/src/unique-cooking-effects/dtos/update-unique-cooking-effect.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsOptional } from 'class-validator';
+
+export class UpdateUniqueCookingEffectDto {
+  @IsString()
+  @IsOptional()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description: string;
+}

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
 import { UpdateUniqueCookingEffectDto } from './dtos/update-unique-cooking-effect.dto';
@@ -30,5 +38,10 @@ export class UniqueCookingEffectsController {
     @Body() body: UpdateUniqueCookingEffectDto,
   ) {
     return this.uniqueCookingEffectsService.update(parseInt(id), body);
+  }
+
+  @Delete('/:id')
+  removeUniqueCookingEffect(@Param('id') id: string) {
+    return this.uniqueCookingEffectsService.remove(parseInt(id));
   }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,4 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
+import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
+import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
 
 @Controller('unique-cooking-effects')
-export class UniqueCookingEffectsController {}
+export class UniqueCookingEffectsController {
+  constructor(
+    private readonly uniqueCookingEffectsService: UniqueCookingEffectsService,
+  ) {}
+
+  @Post()
+  createUniqueCookingEffect(@Body() body: CreateUniqueCookingEffectDto) {
+    return this.uniqueCookingEffectsService.create(body.name, body.description);
+  }
+}

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
+import { UpdateUniqueCookingEffectDto } from './dtos/update-unique-cooking-effect.dto';
 
 @Controller('unique-cooking-effects')
 export class UniqueCookingEffectsController {
@@ -21,5 +22,13 @@ export class UniqueCookingEffectsController {
   @Get('/:id')
   findUniqueCookingEffect(@Param('id') id: string) {
     return this.uniqueCookingEffectsService.findOne(parseInt(id));
+  }
+
+  @Patch('/:id')
+  updateUniqueCookingEffect(
+    @Param('id') id: string,
+    @Body() body: UpdateUniqueCookingEffectDto,
+  ) {
+    return this.uniqueCookingEffectsService.update(parseInt(id), body);
   }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
 
@@ -11,5 +11,15 @@ export class UniqueCookingEffectsController {
   @Post()
   createUniqueCookingEffect(@Body() body: CreateUniqueCookingEffectDto) {
     return this.uniqueCookingEffectsService.create(body.name, body.description);
+  }
+
+  @Get()
+  findAllUniqueCookingEffects() {
+    return this.uniqueCookingEffectsService.find();
+  }
+
+  @Get('/:id')
+  findUniqueCookingEffect(@Param('id') id: string) {
+    return this.uniqueCookingEffectsService.findOne(parseInt(id));
   }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -1,5 +1,9 @@
 import { Repository } from 'typeorm';
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 
@@ -38,5 +42,17 @@ export class UniqueCookingEffectsService {
 
   findOne(id: number) {
     return this.repo.findOneBy({ id });
+  }
+
+  async update(id: number, attrs: Partial<UniqueCookingEffect>) {
+    const uniqueCookingEffect = await this.findOne(id);
+
+    if (!uniqueCookingEffect) {
+      throw new NotFoundException();
+    }
+
+    Object.assign(uniqueCookingEffect, attrs);
+
+    return this.repo.save(uniqueCookingEffect);
   }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -55,4 +55,14 @@ export class UniqueCookingEffectsService {
 
     return this.repo.save(uniqueCookingEffect);
   }
+
+  async remove(id: number) {
+    const uniqueCookingEffect = await this.findOne(id);
+
+    if (!uniqueCookingEffect) {
+      throw new NotFoundException();
+    }
+
+    return this.repo.remove(uniqueCookingEffect);
+  }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -27,4 +27,16 @@ export class UniqueCookingEffectsService {
 
     return this.repo.save(uniqueCookingEffect);
   }
+
+  find() {
+    return this.repo.find({
+      select: {
+        name: true,
+      },
+    });
+  }
+
+  findOne(id: number) {
+    return this.repo.findOneBy({ id });
+  }
 }

--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -1,4 +1,30 @@
-import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 
 @Injectable()
-export class UniqueCookingEffectsService {}
+export class UniqueCookingEffectsService {
+  constructor(
+    @InjectRepository(UniqueCookingEffect)
+    private readonly repo: Repository<UniqueCookingEffect>,
+  ) {}
+
+  async create(name: string, description: string) {
+    const potentialDuplicateCookingEffect = await this.repo.find({
+      where: { name },
+    });
+
+    if (potentialDuplicateCookingEffect.length !== 0) {
+      const { id, name } = potentialDuplicateCookingEffect[0];
+
+      throw new ConflictException(
+        `a 'unique_cooking_effect' record with a 'name' of ${name} already exists as id #${id}`,
+      );
+    }
+
+    const uniqueCookingEffect = this.repo.create({ name, description });
+
+    return this.repo.save(uniqueCookingEffect);
+  }
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no way for an Admin User to CRUD the 'unique-cooking-effects' resource. Further, there was no way for another table that might want to reference this data to be able to reference it in a contained field.

**After The PR (Pull Request):**
There are now routes and 'service' methods that will allow an Admin User to CRUD the 'unique-cooking-effects' resource. Additionally, it is now possible for other tables in the database to access this data should it be relevant to what's contained in them.

**What Was Changed?**
A table providing a reference to which PRs impacted which files of the program may be found below:

| HTTP Request | DTO | `service` | `controller` |
| :---: | :---: | :---: | :---: |
| `POST` | #113 | #114 | #116 |
| `GET` | - | #117 | #118 |
| `PATCH` | #119 | #120 | #121 |
| `DELETE` | - | #122 | #123 |

**Why Was This Changed?**
Prior to the inclusion of this PR there was no way for an Admin User to be able to create, update, or delete a record in the 'unique-cooking-effects' resource. Further, there was no way for the data that would eventually be included in this table to  be included in other relevant points within the rest of the database. With the inclusion of these changes, it is now possible for other tables to reference the data contained in this particular resource as well as for Admin Users to perform CRUD actions on this particular resource.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #44

**Mentions:** _(Type `@` then the person's name)_
N / A 