### PR TITLE
Add 'find()', 'findOne()' Methods To 'service'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -27,4 +27,16 @@ export class UniqueCookingEffectsService {
 
     return this.repo.save(uniqueCookingEffect);
   }
+
+  find() {
+    return this.repo.find({
+      select: {
+        name: true,
+      },
+    });
+  }
+
+  findOne(id: number) {
+    return this.repo.findOneBy({ id });
+  }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
There was no way for an Admin User to retrieve all record data contained in the 'unique-cooking-effect' table or to retrieve a single, specific record row from the 'unique-cooking-effect' table.

**After The PR (Pull Request):**
An Admin User can now retrieve every record row contained within the 'unique-cooking-event' table as well as a single, specific record row within the 'unique-cooking-event' table.

**What Was Changed?**
- Add 'find()' method to the 'service' for returning all 'unique-cooking-effect' records
- Add 'findOne()' method to the 'service' for returning a single, specific 'unique-cooking-effect' record

**Why Was This Changed?**
Prior to the addition of this PR there was no way for the overall application to retrieve either all records contained within the 'unique-cooking-event' table or a single record contained within the 'unique-cooking-event' table. With the inclusion of this PR there is now a way for an Admin User to retrieve both of those data subsets from the 'unique-cooking-event' table.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #101 

**Mentions:** _(Type `@` then the person's name)_
N / A