### PR TITLE
Add 'find...()', 'findAll...()' Methods To 'controller'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
 
@@ -11,5 +11,15 @@ export class UniqueCookingEffectsController {
   @Post()
   createUniqueCookingEffect(@Body() body: CreateUniqueCookingEffectDto) {
     return this.uniqueCookingEffectsService.create(body.name, body.description);
+  }
+
+  @Get()
+  findAllUniqueCookingEffects() {
+    return this.uniqueCookingEffectsService.find();
+  }
+
+  @Get('/:id')
+  findUniqueCookingEffect(@Param('id') id: string) {
+    return this.uniqueCookingEffectsService.findOne(parseInt(id));
   }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Presently the 'find()' and 'findOne()' methods within the 'service' are orphaned and are inaccessible by the larger application, preventing the larger application from retrieving data contained within the 'unique-cooking-effect' table.

**After The PR (Pull Request):**
Routes were created that are dedicated to each of the two types of GET requests that will retrieve either all records contained in the 'unique-cooking-effect' table or a single, specific record row within the 'unique-cooking-effect' table.

**What Was Changed?**
- Add 'findAllUniqueCookingEffects()' method to the module 'controller'
- Add 'findUniqueCookingEffect()` method to the module 'controller'

**Why Was This Changed?**
Once the 'service' 'find...()' methods were instantiated there was no actual route that was created to handle those kinds of requests by the API - so, effectively, those methods were orphaned in the larger application. This PR creates dedicated routes that allow the API to make use of the two GET 'find...()' methods in the service to retrieve all records in the 'unique-cooking-effect' table. 

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #102 

**Mentions:** _(Type `@` then the person's name)_
N / A