### PR TITLE
Add 'update' Method To 'service'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -1,5 +1,9 @@
 import { Repository } from 'typeorm';
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UniqueCookingEffect } from './entities/unique-cooking-effect.entity';
 
@@ -38,5 +42,17 @@ export class UniqueCookingEffectsService {
 
   findOne(id: number) {
     return this.repo.findOneBy({ id });
+  }
+
+  async update(id: number, attrs: Partial<UniqueCookingEffect>) {
+    const uniqueCookingEffect = await this.findOne(id);
+
+    if (!uniqueCookingEffect) {
+      throw new NotFoundException();
+    }
+
+    Object.assign(uniqueCookingEffect, attrs);
+
+    return this.repo.save(uniqueCookingEffect);
   }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
There is no way for an Admin User to update a specific record row contained within the 'unique-cooking-effect' table in the database. 

**After The PR (Pull Request):**
An 'update()' method is created which,  if a record matching the Admin User provided 'id' is found, will update that specific record within table; if such a record is not found an exception will be thrown.

**What Was Changed?**
- Add 'update()' method to the module's 'service'

**Why Was This Changed?**
In order to make a change to a record row in the 'unique-cooking-effect' table we need to have a dedicated method that can execute that change in the repo that is located within our 'service'. This PR creates that method which, if a record matching the Admin User provided 'id' is found, will update that specific record within table; if such a record is not found an exception will be thrown.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #104 

**Mentions:** _(Type `@` then the person's name)_
N / A