### PR TITLE
Add 'remove()' Method To 'service'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.service.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.service.ts
@@ -55,4 +55,14 @@ export class UniqueCookingEffectsService {
 
     return this.repo.save(uniqueCookingEffect);
   }
+
+  async remove(id: number) {
+    const uniqueCookingEffect = await this.findOne(id);
+
+    if (!uniqueCookingEffect) {
+      throw new NotFoundException();
+    }
+
+    return this.repo.remove(uniqueCookingEffect);
+  }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Presently there is no way to remove a specific record row from the 'unique-cooking-effect' table within the database.

**After The PR (Pull Request):**
There is a dedicated method that will allow an Admin User to remove a specific record row from the 'unique-cooking-effect' table within the database.

**What Was Changed?**
- Add 'remove()' method to the module's 'service'

**Why Was This Changed?**
Prior to this PR there was no way for an Admin User to remove a specific record row from the 'unique-cooking-effect' table within the database. After this PR there is now a dedicated method in the module's 'service' that will allow an Admin User to remove a specific record row from the 'unique-cooking-effect' table.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #106 

**Mentions:** _(Type `@` then the person's name)_
N / A