### PR TITLE
Add 'remove...()' Method To 'controller'

### DIFF
--- a/src/unique-cooking-effects/unique-cooking-effects.controller.ts
+++ b/src/unique-cooking-effects/unique-cooking-effects.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
 import { UniqueCookingEffectsService } from './unique-cooking-effects.service';
 import { CreateUniqueCookingEffectDto } from './dtos/create-unique-cooking-effect.dto';
 import { UpdateUniqueCookingEffectDto } from './dtos/update-unique-cooking-effect.dto';
@@ -30,5 +38,10 @@ export class UniqueCookingEffectsController {
     @Body() body: UpdateUniqueCookingEffectDto,
   ) {
     return this.uniqueCookingEffectsService.update(parseInt(id), body);
+  }
+
+  @Delete('/:id')
+  removeUniqueCookingEffect(@Param('id') id: string) {
+    return this.uniqueCookingEffectsService.remove(parseInt(id));
   }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
While the 'service' had a 'remove()' method that could be used to delete a specific record row from the 'unique-cooking-effect' table there was no dedicated route that an Admin User could make use of to access that specific method to enact that change.

**After The PR (Pull Request):**
After this PR there is now a new DELETE route within the 'controller' that grants the Admin User the ability to access the 'remove()' method so they can delete specific record rows from the 'unique-cooking-effect' table.

**What Was Changed?**
- Add 'removeUniqueCookingEffect()' method to the module's 'controller'

**Why Was This Changed?**
Prior to the addition of this PR, while the 'service' had a 'remove()' method that could be used to delete a specific record row from the 'unique-cooking-effect' table there was no dedicated route that an Admin User could make use of to access that specific method to enact that change. After this PR there is now a new DELETE route within the 'controller' that grants the Admin User the ability to access the 'remove()' method so they can delete specific record rows from the 'unique-cooking-effect' table.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #107 

**Mentions:** _(Type `@` then the person's name)_
N / A