### PR TITLE
Update 'material' Entity, Add 'dtos/' Directory & 'create-materials' DTO

### DIFF
--- a/src/materials/dtos/create-material.dto.ts
+++ b/src/materials/dtos/create-material.dto.ts
@@ -1,0 +1,24 @@
+import { IsBoolean, IsNumber, IsString } from 'class-validator';
+
+export class CreateMaterialDto {
+  @IsString()
+  readonly name: string;
+
+  @IsString()
+  readonly description: string;
+
+  @IsNumber()
+  readonly fuse_attack_power: number;
+
+  @IsNumber()
+  readonly hearts_recovered: number;
+
+  @IsNumber()
+  readonly unique_cooking_effect: number;
+
+  @IsNumber({ allowInfinity: false, allowNaN: false }, { each: true })
+  readonly common_location: number[];
+
+  @IsBoolean()
+  readonly tradeable: boolean;
+}

--- a/src/materials/entities/material.entity.ts
+++ b/src/materials/entities/material.entity.ts
@@ -14,15 +14,15 @@ export class Material {
   @Column()
   fuse_attack_power: number;
 
-  @Column()
+  @Column({ nullable: true })
   hearts_recovered: number;
 
-  @Column()
+  @Column({ nullable: true })
   unique_cooking_effects: string;
 
   @Column()
   common_locations: string;
 
-  @Column()
+  @Column({ nullable: true })
   tradeable: boolean;
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no way for an Admin User to demarcate that a particular column was 'nullable' for accurate representation of game data within the application. Additionally, there was no DTO that could be used for a potential POST request upon the instantiation of an appropriate route within the 'material' module's 'controller' and 'service'.

**After The PR (Pull Request):**
Including this PR solves the problem that an Admin User cannot leave a particular field within the 'material' column as 'null' (indicating that the record row does not possess that particular feature / trait / field). Further, the PR creates a directory and initial 'create-material' DTO which can be used for the creation of 'material' record rows when a POST request is made.

**What Was Changed?**
- 'nullable' option was added to 'hearts_recovered', 'unique_cooking_effects', & 'tradeable' columns in the 'material' Entity file
- Created a 'dtos/' directory within the 'materials' module
- Add 'create-material' DTO file in the 'materials/dtos/' module directory

**Why Was This Changed?**
The 'nullable' option was added to those three entity columns because there is no guarantee that a particular 'material' record row is going to have a 'hearts_recovered' property, 'unique_cooking_effects' property, or a 'tradeable' property within the context of the game.

The 'dtos/' directory and 'create-material' DTO were created to facilitate easier creation of a record row within the 'material' resource / table.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #125 

**Mentions:** _(Type `@` then the person's name)_
N / A