### PR TITLE
Update 'material' Entity, Update 'create-material' DTO, Add 'create()' Method To 'materials' Service

### DIFF
--- a/src/materials/dtos/create-material.dto.ts
+++ b/src/materials/dtos/create-material.dto.ts
@@ -13,11 +13,11 @@ export class CreateMaterialDto {
   @IsNumber()
   readonly hearts_recovered: number;
 
-  @IsNumber()
-  readonly unique_cooking_effect: number;
+  @IsString()
+  readonly unique_cooking_effect: string;
 
-  @IsNumber({ allowInfinity: false, allowNaN: false }, { each: true })
-  readonly common_location: number[];
+  @IsString({ each: true })
+  readonly common_locations: string[];
 
   @IsBoolean()
   readonly tradeable: boolean;

--- a/src/materials/entities/material.entity.ts
+++ b/src/materials/entities/material.entity.ts
@@ -18,10 +18,10 @@ export class Material {
   hearts_recovered: number;
 
   @Column({ nullable: true })
-  unique_cooking_effects: string;
+  unique_cooking_effect: string;
 
-  @Column()
-  common_locations: string;
+  @Column('json')
+  common_locations: string[];
 
   @Column({ nullable: true })
   tradeable: boolean;

--- a/src/materials/materials.service.ts
+++ b/src/materials/materials.service.ts
@@ -1,4 +1,45 @@
-import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Material } from './entities/material.entity';
 
 @Injectable()
-export class MaterialsService {}
+export class MaterialsService {
+  constructor(
+    @InjectRepository(Material) private readonly repo: Repository<Material>,
+  ) {}
+
+  async create(
+    name: string,
+    description: string,
+    fuse_attack_power: number,
+    hearts_recovered: number,
+    unique_cooking_effect: string,
+    common_locations: string[],
+    tradeable: boolean,
+  ) {
+    const potentialDuplicateMaterial = await this.repo.find({
+      where: { name },
+    });
+
+    if (potentialDuplicateMaterial.length !== 0) {
+      const { id, name } = potentialDuplicateMaterial[0];
+
+      throw new ConflictException(
+        `A 'material' record with a 'name' of ${name} already exists as id #${id}`,
+      );
+    }
+
+    const material = this.repo.create({
+      name,
+      description,
+      fuse_attack_power,
+      hearts_recovered,
+      unique_cooking_effect,
+      common_locations,
+      tradeable,
+    });
+
+    return this.repo.save(material);
+  }
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR a bug was introduced that left the 'material' entity and 'create-material' DTO files out of sync by both type and field name for a couple fields. Additionally, there was no 'service' method that would allow a future route in the 'controller' the ability to instantiate a new record row in the 'materials' table in the database.

**After The PR (Pull Request):**
With the inclusion of this PR there is now synchronicity between the 'material' entity and the 'create-material' DTO. Additionally, there is now an access point for a future route in the 'controller' to be able to instantiate a record row in the 'materials' table in the database.

**What Was Changed?**
- Two 'material' entity fields were amended:
  1. The 'unique_cooking_effects' field was made singular and adjusted to take a string and not a number
  2. The 'common_locations' field was changed to accept an array of strings instead of a number and the column was formatted to accept a JSON object
- Two 'create-material' DTO fields were amended:
  1. The 'unique_cooking_effect' field now takes a string
  2. The 'common_location' field was made plural and now accepts an array of strings
- A 'create()' method was added to the 'materials' module's 'service', along with a 'constructor()' method

**Why Was This Changed?**
The 'material' entity was amended to more accurately reflect the data in the specific fields. Additionally, these changes were made to make it easier on the developer (aka me) to be able to figure out how I wanted the data to show in the table - prior to adding in relationships between various tables - as well as how I wanted the data to show when it was eventually returned by a request to the server.

The 'create-material' DTO was amended to be an identical match to the new 'material' entity that had been amended in this PR.

The 'create()' method was added to the 'materials' module's 'service' (along with a 'constructor()' method) so that there would be an easy way for a route to the module's 'controller' to be able to access and create a record row within the 'materials' table in the database.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #126 

**Mentions:** _(Type `@` then the person's name)_
N / A