### PR TITLE
Amend 'create-material' DTO, Add 'findAll...()' & 'find...()' Methods To Module 'controller'

### DIFF
--- a/src/materials/dtos/create-material.dto.ts
+++ b/src/materials/dtos/create-material.dto.ts
@@ -14,6 +14,7 @@ export class CreateMaterialDto {
   readonly fuse_attack_power: number;
 
   @IsNumber()
+  @IsOptional()
   readonly hearts_recovered: number;
 
   @IsString()
@@ -24,5 +25,6 @@ export class CreateMaterialDto {
   readonly common_locations: string[];
 
   @IsBoolean()
+  @IsOptional()
   readonly tradeable: boolean;
 }

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { MaterialsService } from './materials.service';
 import { CreateMaterialDto } from './dtos/create-material.dto';
 
@@ -18,5 +18,15 @@ export class MaterialsController {
       body.common_locations,
       body.tradeable,
     );
+  }
+
+  @Get()
+  findAllMaterials() {
+    return this.materialsService.find();
+  }
+
+  @Get(':/id')
+  findMaterial(@Param('id') id: string) {
+    return this.materialsService.findOne(parseInt(id));
   }
 }


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR, an Admin User needs to include the 'hearts_recovered' and 'tradeable' key / value pairs in a POST request, even though a material listed in the TotK game may not have those attributes. Additionally, there is presently no route that will allow a GET request from any User to retrieve data about one or all record rows kept within the 'materials' table.

**After The PR (Pull Request):**
With the inclusion of this PR, an Admin User now has the ability to not provide 'hearts_recovered' and 'tradeable' key / value pairs in a POST request as, in TotK, not every material in the game has those attributes. Further, two additional 'find...()' methods were added to the 'controller' allowing any User to retrieve data from the 'materials' table.

**What Was Changed?**
- Amend Two Fields In 'create-material' DTO:
  1. Add 'IsOptional()' decorator to 'hearts_recovered' field
  2. Add 'IsOptional()' decorator to 'tradeable' field
- Add 'findMaterials()' and 'findAllMaterials()' methods to the module's 'controller'

**Why Was This Changed?**
The two decorators that were added to the 'hearts_recovered' and 'tradeable' fields in the 'create-material' DTO were included as those fields will be null for some materials within TotK and to ensure parity between game data and the application those fields needed to be amended.

The 'findMaterials()' and 'findAllMaterials()' methods were added so that routing would allow any User the ability to retrieve data from 'materials' table.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #129 

**Mentions:** _(Type `@` then the person's name)_
N / A