### PR TITLE
Add 'update-material' DTO

### DIFF
--- a/src/materials/dtos/update-material.dto.ts
+++ b/src/materials/dtos/update-material.dto.ts
@@ -1,0 +1,35 @@
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UpdateMaterialDto {
+  @IsNumber()
+  @IsOptional()
+  readonly id: number;
+
+  @IsString()
+  @IsOptional()
+  readonly name: string;
+
+  @IsString()
+  @IsOptional()
+  readonly description: string;
+
+  @IsNumber()
+  @IsOptional()
+  readonly fuse_attack_power: number;
+
+  @IsNumber()
+  @IsOptional()
+  readonly hearts_recovered: number;
+
+  @IsString()
+  @IsOptional()
+  readonly unique_cooking_effect: string;
+
+  @IsString({ each: true })
+  @IsOptional()
+  readonly common_locations: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  readonly tradeable: boolean;
+}


### PR DESCRIPTION
**Before The PR (Pull Request):**
Prior to this PR there was no data schema / DTO that would allow an Admin User to make dynamic changes to specific record rows within the 'materials' table in the database.

**After The PR (Pull Request):**
After this PR Admin Users will now have a scaffold that will allow them to make dynamic changes to specific record rows within the 'materials' table in the database.

**What Was Changed?**
- A new DTO file ('update-material') was added to the 'dtos/' directory in the 'materials' module which will allow Admin Users to make changes to specific record rows within the 'materials' table

**Why Was This Changed?**
Adding a new 'update-material' DTO file will allow Admin Users to make dynamic changes to a specific record row within the 'materials' table in the database.

**Related Issues Resolved By This PR (Pull Request):** _(Type `#` then the issue number)_
Resolves #130 

**Mentions:** _(Type `@` then the person's name)_
N / A